### PR TITLE
Add source-repository stanza

### DIFF
--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -13,6 +13,10 @@ build-type:          Simple
 extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
+source-repository head
+  type:                git
+  location:            https://github.com/GaloisInc/language-sally
+
 library
   build-depends:       base           >= 4.8   && < 5
                      , bytestring     >= 0.10


### PR DESCRIPTION
Because I wasn't sure where this project was located at first.

(OK, I _did_ know where it was located. But I'm lazy and like to get to places by just clicking links from libraries' Hackage pages.)