### PR TITLE
v0.3.0.0: update to upstream changes in crucible and what4

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for language-sally
 
+## 0.3.0.0  -- 2021-03-22
+
+* Adapt to changes in Crucible and What4
+
 ## 0.2.1.0  -- 2020-06-16
 
 * Reserve the "query" namespace to use for creating What4 queries.

--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -3,11 +3,9 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: f3584724108f96dcafe8138730441bedf6a0cbe2f60e67dc094457ca40f09afb
 
 name:           language-sally
-version:        0.2.1.0
+version:        0.3.0.0
 synopsis:       AST and pretty printer for Sally
 description:    AST and pretty printer for the Sally
                 <https://github.com/SRI-CSL/sally> input language
@@ -41,7 +39,7 @@ library
   ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
   build-depends:
       ansi-wl-pprint >=0.6 && <0.7
-    , base >=4.8 && <4.14
+    , base >=4.8 && <4.15
     , bytestring
     , containers >=0.5 && <0.7
     , extra
@@ -49,5 +47,5 @@ library
     , mtl
     , parameterized-utils >=2.0
     , text
-    , what4
+    , what4 >=1.1 && <1.2
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -6,7 +6,7 @@ copyright: Galois, Inc. 2017-2020
 
 dependencies:
   - ansi-wl-pprint ^>= 0.6
-  - base >= 4.8 && < 4.14
+  - base >= 4.8 && < 4.15
   - bytestring
   - containers >= 0.5 && < 0.7
   - extra
@@ -14,7 +14,7 @@ dependencies:
   - mtl
   - parameterized-utils >= 2.0
   - text
-  - what4
+  - what4 ^>= 1.1
 
 description: |
   AST and pretty printer for the Sally
@@ -45,4 +45,4 @@ name: language-sally
 
 synopsis: AST and pretty printer for Sally
 
-version: 0.2.1.0
+version: 0.3.0.0

--- a/src/Language/Sally/SExp.hs
+++ b/src/Language/Sally/SExp.hs
@@ -335,16 +335,13 @@ sexpOfSally
       sallyTransitions
     } = do
     bindings <- getSymbolVarBimap sym
-    inStr <- Streams.encodeUtf8 Streams.stderr
+    noInput <- Streams.nullInput
+    errorStream <- Streams.encodeUtf8 Streams.stderr
     conn <-
       liftIO $
         newWriter
-          ()
-          inStr
-          nullAcknowledgementAction
-          "NoSolver"
-          defaultWriteSMTLIB2Features
-          bindings
+          noInput errorStream nullAcknowledgementAction
+          "NoSolver" defaultWriteSMTLIB2Features bindings
     let symbols = toListFC getConst (sallyStateVarsNames sallyState)
     flip runReaderT symbols $ do
       state <- liftIO $ sexpOfSallyState conn sallyState

--- a/src/Language/Sally/Writer.hs
+++ b/src/Language/Sally/Writer.hs
@@ -140,11 +140,7 @@ instance SupportTermOps (SallyReader SMT2.Term) where
   bvSLt = liftA2 bvSLt
   bvULt = liftA2 bvULt
   bvUDiv = liftA2 bvUDiv
-  floatPZero = pure . floatPZero
-  floatNZero = pure . floatNZero
-  floatNaN = pure . floatNaN
-  floatPInf = pure . floatPInf
-  floatNInf = pure . floatNInf
+  floatTerm p = pure . floatTerm p
   floatNeg = fmap floatNeg
   floatAbs = fmap floatAbs
   floatSqrt rm = fmap (floatSqrt rm)
@@ -153,8 +149,6 @@ instance SupportTermOps (SallyReader SMT2.Term) where
   floatMul rm = liftA2 (floatMul rm)
   floatDiv rm = liftA2 (floatDiv rm)
   floatRem = liftA2 floatRem
-  floatMin = liftA2 floatMin
-  floatMax = liftA2 floatMax
   floatFMA rm = liftA3 (floatFMA rm)
   floatEq = liftA2 floatEq
   floatFpEq = liftA2 floatFpEq
@@ -297,7 +291,7 @@ unhandled :: String -> IO a
 unhandled construct = error $ "Unhandled by language-sally: " ++ construct ++ ", please report to maintainers."
 
 newWriter ::
-  a ->
+  Streams.InputStream Text ->
   Streams.OutputStream Text ->
   -- | Action to run for consuming acknowledgement messages
   AcknowledgementAction t (SallyWriter a) ->
@@ -308,7 +302,7 @@ newWriter ::
   -- | Indicates if quantifiers are supported.
   SymbolVarBimap t ->
   IO (WriterConn t (SallyWriter a))
-newWriter _ h ack solver_name arithOption bindings = do
+newWriter in_stream out_stream ack solver_name arithOption bindings = do
   let initWriter = SallyWriter
-  conn <- newWriterConn h ack solver_name arithOption bindings initWriter
+  conn <- newWriterConn out_stream in_stream ack solver_name arithOption bindings initWriter
   return $! conn {supportFunctionDefs = False, supportQuantifiers = False}


### PR DESCRIPTION
This is in support of fixing https://github.com/GaloisInc/crucible/issues/670 without fixing an outdated version of crucible-mc.