### PR TITLE
Allow building with base-4.15 (GHC 9.0)

### DIFF
--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -42,7 +42,7 @@ library
 
   build-depends:
     , ansi-wl-pprint       ^>=0.6
-    , base                 >=4.8 && <4.15
+    , base                 >=4.8 && <4.16
     , bytestring
     , containers           >=0.5 && <0.7
     , extra


### PR DESCRIPTION
I am able to build `language-sally` (in combination with the corresponding `what4` changes in GaloisInc/what4#110) without issue.