### PR TITLE
language-sally-0.4.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dependencies/what4"]
+	path = dependencies/what4
+	url = https://github.com/GaloisInc/what4

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages: ./
+
+optional-packages:
+  dependencies/what4/what4/
+  dependencies/what4/what4-transition-system/

--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               language-sally
-version:            0.3.0.0
+version:            0.4.0.0
 synopsis:           AST and pretty printer for Sally
 description:
   AST and pretty printer for the Sally
@@ -12,11 +12,8 @@ author:
   Benjamin Jones <bjones@galois.com>
   Valentin Robert <val@galois.com>
 
-maintainer:
-  Benjamin Jones <bjones@galois.com>
-  Valentin Robert <val@galois.com>
-
-copyright:          Galois, Inc. 2017-2021
+maintainer:         Valentin Robert <val@galois.com>
+copyright:          Galois, Inc. 2017-2022
 license:            BSD-3-Clause
 license-file:       LICENSE
 build-type:         Simple
@@ -30,6 +27,7 @@ library
   exposed-modules:
     Language.Sally
     Language.Sally.SExp
+    Language.Sally.TransitionSystem
     Language.Sally.Types
     Language.Sally.Writer
 
@@ -41,15 +39,16 @@ library
     -Werror=overlapping-patterns
 
   build-depends:
-    , ansi-wl-pprint       ^>=0.6
-    , base                 >=4.8 && <4.16
+    , ansi-wl-pprint           >=0.6
+    , base                     >=4.8   && <4.16
     , bytestring
-    , containers           >=0.5 && <0.7
+    , containers               >=0.5   && <0.7
     , extra
     , io-streams
     , mtl
-    , parameterized-utils  >=2.0 && <2.2
+    , parameterized-utils      >=2.0   && <2.2
     , text
-    , what4                ^>=1.2
+    , what4                    >=1.2
+    , what4-transition-system  >=0.0.3
 
   default-language: Haskell2010

--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -23,7 +23,15 @@ source-repository head
   type:     git
   location: https://github.com/GaloisInc/language-sally
 
+common dependencies
+  build-depends:
+    , base                     >=4.8   && <4.16
+    , parameterized-utils      >=2.0   && <2.2
+    , what4                    >=1.2
+    , what4-transition-system  >=0.0.3
+
 library
+  import:           dependencies
   exposed-modules:
     Language.Sally
     Language.Sally.SExp
@@ -40,15 +48,25 @@ library
 
   build-depends:
     , ansi-wl-pprint           >=0.6
-    , base                     >=4.8   && <4.16
     , bytestring
     , containers               >=0.5   && <0.7
     , extra
     , io-streams
     , mtl
-    , parameterized-utils      >=2.0   && <2.2
     , text
-    , what4                    >=1.2
-    , what4-transition-system  >=0.0.3
 
+  default-language: Haskell2010
+
+test-suite language-sally-tests
+  import:           dependencies
+  type:             exitcode-stdio-1.0
+  main-is:          Main.hs
+  hs-source-dirs:   test
+  ghc-options:
+    -Wall -Werror=incomplete-patterns -Werror=missing-methods
+    -Werror=overlapping-patterns
+
+  build-depends:
+    , language-sally
+    , lens
   default-language: Haskell2010

--- a/src/Language/Sally.hs
+++ b/src/Language/Sally.hs
@@ -4,7 +4,7 @@
 -- Copyright   : (c) Galois Inc, 2020
 -- License     : BSD3
 --
--- Maintainer  : valentin.robert.42@gmail.com
+-- Maintainer  : val@galois.com
 -- Stability   : experimental
 -- |
 module Language.Sally

--- a/src/Language/Sally/SExp.hs
+++ b/src/Language/Sally/SExp.hs
@@ -10,7 +10,7 @@
 -- Copyright   : (c) Galois Inc, 2020
 -- License     : BSD3
 --
--- Maintainer  : valentin.robert.42@gmail.com
+-- Maintainer  : val@galois.com
 -- Stability   : experimental
 -- |
 module Language.Sally.SExp

--- a/src/Language/Sally/TransitionSystem.hs
+++ b/src/Language/Sally/TransitionSystem.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeOperators #-}
 
 -- |
--- Module      : What4.TransitionSystem.Exporter.Sally
+-- Module      : Language.Sally.TransitionSystem
 -- Description : Export What4 transition system to the Sally format
 -- Copyright   : (c) Galois Inc, 2020-2021
 -- License     : BSD3

--- a/src/Language/Sally/TransitionSystem.hs
+++ b/src/Language/Sally/TransitionSystem.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- |
+-- Module      : What4.TransitionSystem.Exporter.Sally
+-- Description : Export What4 transition system to the Sally format
+-- Copyright   : (c) Galois Inc, 2020-2021
+-- License     : BSD3
+-- Maintainer  : val@galois.com
+module Language.Sally.TransitionSystem
+  ( exportTransitionSystem,
+    mySallyNames,
+  )
+where
+
+import qualified Data.Parameterized.Context as Ctx
+import qualified Language.Sally as S
+import What4.Expr (ExprBuilder)
+import qualified What4.Interface as What4
+import qualified What4.TransitionSystem as TS
+import Prelude hiding (init)
+
+data SallyNames = SallyNames
+  { -- | Name of the initial state predicate
+    initialName :: S.Name,
+    -- | Name of the main transition
+    mainTransitionName :: S.Name,
+    -- | Name of the state type
+    stateName :: S.Name,
+    -- | Name of the transition system
+    systemName :: S.Name
+  }
+
+-- | @mySallyNames@ has some default names since we currently don't care too
+-- much about changing them
+mySallyNames :: SallyNames
+mySallyNames =
+  SallyNames
+    { initialName = TS.userSymbol' "InitialState",
+      mainTransitionName = TS.userSymbol' "MainTransition",
+      stateName = TS.userSymbol' "State",
+      systemName = TS.userSymbol' "System"
+    }
+
+sallyState ::
+  SallyNames ->
+  TS.TransitionSystem sym stateType ->
+  S.SallyState stateType Ctx.EmptyCtx
+sallyState
+  (SallyNames {stateName})
+  (TS.TransitionSystem {TS.stateNames, TS.stateReprs}) =
+    S.SallyState
+      { S.sallyStateName = stateName,
+        S.sallyStateVars = stateReprs,
+        S.sallyStateVarsNames = stateNames,
+        S.sallyStateInputs = Ctx.Empty,
+        S.sallyStateInputsNames = Ctx.Empty
+      }
+
+sallyQuery :: S.Name -> What4.Pred (ExprBuilder t st fs) -> S.SallyQuery t
+sallyQuery systemName sallyQueryPredicate =
+  S.SallyQuery
+    { S.sallyQuerySystemName = systemName,
+      -- sqLet = [],
+      S.sallyQueryPredicate,
+      S.sallyQueryComment = ""
+    }
+
+exportTransitionSystem ::
+  ExprBuilder t st fs ->
+  SallyNames ->
+  TS.TransitionSystem (ExprBuilder t st fs) stateType ->
+  IO (S.Sally t stateType Ctx.EmptyCtx Ctx.EmptyCtx)
+exportTransitionSystem
+  sym
+  (sn@SallyNames {initialName, mainTransitionName, stateName, systemName})
+  ts =
+    do
+      sallyStateFormulaPredicate <- TS.makeInitialState sym ts
+      sallyTransitions <-
+        TS.makeTransitions
+          sym
+          mainTransitionName
+          (S.SallyTransition stateName)
+          ts
+      sallyQueries <- TS.makeQueries sym (sallyQuery systemName) ts
+      let sallyInitialFormula =
+            S.SallyStateFormula
+              { S.sallyStateFormulaName = initialName,
+                S.sallyStateFormulaDomain = stateName,
+                S.sallyStateFormulaPredicate
+              }
+      let sallySystem =
+            S.SallySystem
+              { S.sallySystemName = systemName,
+                S.sallySystemStateName = stateName,
+                S.sallySystemInitialStateName = initialName,
+                S.sallySystemTransitionName = mainTransitionName
+              }
+      return $
+        S.Sally
+          { S.sallyState = sallyState sn ts,
+            S.sallyFormulas = [],
+            S.sallyConstants = Ctx.Empty,
+            S.sallyInitialFormula,
+            S.sallyTransitions,
+            S.sallySystem,
+            S.sallyQueries
+          }

--- a/src/Language/Sally/Types.hs
+++ b/src/Language/Sally/Types.hs
@@ -13,7 +13,7 @@
 -- Copyright   : (c) Galois Inc, 2020
 -- License     : BSD3
 --
--- Maintainer  : valentin.robert.42@gmail.com
+-- Maintainer  : val@galois.com
 -- Stability   : experimental
 -- |
 module Language.Sally.Types

--- a/src/Language/Sally/Writer.hs
+++ b/src/Language/Sally/Writer.hs
@@ -14,7 +14,7 @@
 -- Copyright   : (c) Galois Inc, 2020
 -- License     : BSD3
 --
--- Maintainer  : valentin.robert.42@gmail.com
+-- Maintainer  : val@galois.com
 -- Stability   : experimental
 -- |
 module Language.Sally.Writer
@@ -174,9 +174,11 @@ instance SupportTermOps (SallyReader SMT2.Term) where
   realDiv = liftA2 realDiv
   realSin = fmap realSin
   realCos = fmap realCos
+  realTan = fmap realTan
   realATan2 = liftA2 realATan2
   realSinh = fmap realSinh
   realCosh = fmap realCosh
+  realTanh = fmap realTanh
   realExp = fmap realExp
   realLog = fmap realLog
   smtFnApp f as = smtFnApp <$> f <*> sequence as
@@ -201,8 +203,8 @@ instance SupportTermOps (SallyReader SMT2.Term) where
 -- must substitute instances of @init.field@ with simply a naked @field@.  This
 -- is done in @structProj@.
 instance SMTLib2Tweaks a => SMTWriter (SallyWriter a) where
-  forallExpr vars t = SMT2.forall (varBinding @a <$> vars) <$> t
-  existsExpr vars t = SMT2.exists (varBinding @a <$> vars) <$> t
+  forallExpr vars t = SMT2.forall_ (varBinding @a <$> vars) <$> t
+  existsExpr vars t = SMT2.exists_ (varBinding @a <$> vars) <$> t
 
   arrayConstant =
     case smtlib2arrayConstant @a of

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Module      : Main
+-- Copyright   : (c) Galois Inc, 2020-2021
+-- License     : BSD3
+-- Maintainer  : val@galois.com
+-- |
+module Main where
+
+import qualified Control.Lens as L
+import Control.Monad (join)
+import Data.Parameterized (knownRepr)
+import qualified Data.Parameterized.Context as Ctx
+import Data.Parameterized.Nonce (withIONonceGenerator)
+import Language.Sally (Name, sexpOfSally, sexpToCompactDoc)
+import qualified Language.Sally.TransitionSystem as Sally
+import qualified What4.BaseTypes as BaseTypes
+import What4.Expr
+  ( ExprBuilder,
+    FloatModeRepr (FloatIEEERepr),
+    newExprBuilder,
+    EmptyExprBuilderState(..)
+  )
+import What4.Expr.Builder (SymbolBinding (..))
+import qualified What4.Interface as What4
+import What4.TransitionSystem (TransitionSystem (..), userSymbol')
+import Prelude hiding (init)
+
+showBinding :: SymbolBinding t -> String
+showBinding (VarSymbolBinding x) = show x
+showBinding (FnSymbolBinding x) = show x
+
+displayTransitionSystem ::
+  sym ~ ExprBuilder t st fs =>
+  sym ->
+  TransitionSystem sym stateFields ->
+  IO ()
+displayTransitionSystem sym transitionSystem =
+  do
+    sts <- Sally.exportTransitionSystem sym Sally.mySallyNames transitionSystem
+    sexp <- sexpOfSally sym sts
+    print . sexpToCompactDoc $ sexp
+
+main :: IO ()
+main =
+  do
+    withIONonceGenerator $ \nonceGen -> do
+      sym <- newExprBuilder FloatIEEERepr EmptyExprBuilderState nonceGen
+      ts <- counterTransitionSystem sym
+      displayTransitionSystem sym ts
+    withIONonceGenerator $ \nonceGen -> do
+      sym <- newExprBuilder FloatIEEERepr EmptyExprBuilderState nonceGen
+      ts <- realsTransitionSystem sym
+      displayTransitionSystem sym ts
+
+makeFieldNames ::
+  forall stateType.
+  [What4.SolverSymbol] ->
+  Ctx.Assignment BaseTypes.BaseTypeRepr stateType ->
+  Ctx.Assignment (L.Const What4.SolverSymbol) stateType
+makeFieldNames fields rep = Ctx.generate (Ctx.size rep) generator
+  where
+    generator :: Ctx.Index stateType tp -> L.Const What4.SolverSymbol tp
+    generator index = L.Const (fields !! (Ctx.indexVal index))
+
+--
+-- Example 1: a simple counter
+--
+type CounterStateType = Ctx.EmptyCtx Ctx.::> BaseTypes.BaseBoolType Ctx.::> BaseTypes.BaseIntegerType
+
+counterStateFields :: [What4.SolverSymbol]
+counterStateFields = userSymbol' <$> ["counterIsEven", "counter"]
+
+counterFieldNames :: Ctx.Assignment (L.Const What4.SolverSymbol) CounterStateType
+counterFieldNames = makeFieldNames counterStateFields knownRepr
+
+counterIsEven :: Ctx.Index CounterStateType BaseTypes.BaseBoolType
+counterIsEven = Ctx.natIndex @0
+
+counter :: Ctx.Index CounterStateType BaseTypes.BaseIntegerType
+counter = Ctx.natIndex @1
+
+-- | Example initial state predicate, this one constrains the `bool` field to be
+-- true, and the `nat` field to be equal to zero
+counterInitial ::
+  What4.IsSymExprBuilder sym =>
+  sym ->
+  -- | mapping to a variable for each state field
+  What4.SymStruct sym CounterStateType ->
+  IO (What4.Pred sym)
+counterInitial sym init =
+  do
+    initCounterIsEven <- What4.structField sym init counterIsEven
+    initCounter <- What4.structField sym init counter
+    nZero <- What4.intLit sym 0
+    natCond <- What4.intEq sym initCounter nZero
+    andCond <- What4.andPred sym initCounterIsEven natCond
+    return andCond
+
+-- | Example state transition, here, during a transition, the boolean gets
+-- negated, and the natural number gets incremented.  One property of such a
+-- system would be that when the boolean is false, the number is even (assuming
+-- a false and zero initial state).
+counterTransitions ::
+  What4.IsSymExprBuilder sym =>
+  sym ->
+  -- | current state
+  What4.SymStruct sym CounterStateType ->
+  -- | next state
+  What4.SymStruct sym CounterStateType ->
+  IO [(Name, What4.Pred sym)]
+counterTransitions sym state next =
+  do
+    stateCounterIsEven <- What4.structField sym state counterIsEven
+    stateCounter <- What4.structField sym state counter
+    nextCounterIsEven <- What4.structField sym next counterIsEven
+    nextCounter <- What4.structField sym next counter
+    -- (= next.counter (+ 1 state.counter))
+    nOne <- What4.intLit sym 1
+    nStatePlusOne <- What4.intAdd sym nOne stateCounter
+    natCond <- What4.intEq sym nextCounter nStatePlusOne
+    -- (= next.counterIsEven (not state.counterIsEven))
+    bStateNeg <- What4.notPred sym stateCounterIsEven
+    boolCond <- What4.eqPred sym nextCounterIsEven bStateNeg
+    andCond <- What4.andPred sym boolCond natCond
+    return [(userSymbol' "CounterTransition", andCond)]
+
+-- | TODO
+counterTransitionSystem ::
+  ExprBuilder t st fs ->
+  IO (TransitionSystem (ExprBuilder t st fs) CounterStateType)
+counterTransitionSystem sym =
+  do
+    return $
+      TransitionSystem
+        { stateReprs = knownRepr,
+          stateNames = counterFieldNames,
+          initialStatePredicate = counterInitial sym,
+          stateTransitions = counterTransitions sym,
+          queries = const (pure [])
+        }
+
+--
+-- Example 2: using real numbers
+--
+
+-- based on sally/test/regress/bmc/nra/algebraic.mcmt
+
+type RealsStateType =
+  Ctx.EmptyCtx
+    Ctx.::> BaseTypes.BaseRealType
+    Ctx.::> BaseTypes.BaseRealType
+    Ctx.::> BaseTypes.BaseRealType
+
+realsStateFields :: [What4.SolverSymbol]
+realsStateFields = userSymbol' <$> ["P", "x", "n"]
+
+realsFieldNames :: Ctx.Assignment (L.Const What4.SolverSymbol) RealsStateType
+realsFieldNames = makeFieldNames realsStateFields knownRepr
+
+pReals :: Ctx.Index RealsStateType BaseTypes.BaseRealType
+pReals = Ctx.natIndex @0
+
+xReals :: Ctx.Index RealsStateType BaseTypes.BaseRealType
+xReals = Ctx.natIndex @1
+
+nReals :: Ctx.Index RealsStateType BaseTypes.BaseRealType
+nReals = Ctx.natIndex @2
+
+realsInitial ::
+  What4.IsSymExprBuilder sym =>
+  sym ->
+  -- | mapping to a variable for each state field
+  What4.SymStruct sym RealsStateType ->
+  IO (What4.Pred sym)
+realsInitial sym init =
+  do
+    pInit <- What4.structField sym init pReals
+    nInit <- What4.structField sym init nReals
+    -- (and (= P 1) (= n 0))
+    join
+      ( What4.andPred sym
+          <$> (What4.realEq sym pInit =<< What4.realLit sym 1)
+          <*> (What4.realEq sym nInit =<< What4.realLit sym 0)
+      )
+
+realsTransitions ::
+  What4.IsSymExprBuilder sym =>
+  sym ->
+  -- | current state
+  What4.SymStruct sym RealsStateType ->
+  -- | next state
+  What4.SymStruct sym RealsStateType ->
+  IO [(Name, What4.Pred sym)]
+realsTransitions sym state next =
+  do
+    pState <- What4.structField sym state pReals
+    xState <- What4.structField sym state xReals
+    nState <- What4.structField sym state nReals
+    pNext <- What4.structField sym next pReals
+    xNext <- What4.structField sym next xReals
+    nNext <- What4.structField sym next nReals
+    -- (= next.P (* state.P state.x)
+    c1 <- join $ What4.realEq sym pNext <$> What4.realMul sym pState xState
+    -- (= next.n (+ state.n 1))
+    c2 <- join $ What4.realEq sym nNext <$> (What4.realAdd sym nState =<< What4.realLit sym 1)
+    -- (= next.x state.x)
+    c3 <- What4.realEq sym xNext xState
+    t <- What4.andPred sym c1 =<< What4.andPred sym c2 c3
+    return [(userSymbol' "RealsTransition", t)]
+
+-- | TODO
+realsTransitionSystem ::
+  ExprBuilder t st fs ->
+  IO (TransitionSystem (ExprBuilder t st fs) RealsStateType)
+realsTransitionSystem sym =
+  do
+    return $
+      TransitionSystem
+        { stateReprs = knownRepr,
+          stateNames = realsFieldNames,
+          initialStatePredicate = realsInitial sym,
+          stateTransitions = realsTransitions sym,
+          queries = const (pure [])
+        }


### PR DESCRIPTION
This version introduces the `Language.Sally.TransitionSystem` module,
which used to be part of the `what4-transition-system` project but made
maintenance awful by introducing cycles in the dependencies.

The module could arguably be moved to its own Haskell package, but
currently it is not worth the effort to keep track of it separately.