### PR TITLE
Add support for Sally input variables

### DIFF
--- a/src/Language/Sally/SExp.hs
+++ b/src/Language/Sally/SExp.hs
@@ -156,7 +156,7 @@ inlineSpuriousLetBindings ((letBinder, letBody) : lets, body) =
 
 sexpOfExpr ::
   MonadIO m =>
-  MonadReader [What4.SolverSymbol] m =>
+  MonadReader SallyNames m =>
   WriterConn sym (SallyWriter ()) ->
   Expr sym bt ->
   m SExp
@@ -174,7 +174,7 @@ sexpOfExpr conn expr = do
 -- is, expressions returning a boolean.
 sexpOfPred ::
   MonadIO m =>
-  MonadReader [What4.SolverSymbol] m =>
+  MonadReader SallyNames m =>
   WriterConn sym (SallyWriter ()) ->
   Expr sym What4.BaseBoolType ->
   m SExp
@@ -239,7 +239,7 @@ sexpOfSallyState
 
 sexpOfSallyStateFormula ::
   MonadIO m =>
-  MonadReader [What4.SolverSymbol] m =>
+  MonadReader SallyNames m =>
   WriterConn t (SallyWriter ()) ->
   SallyStateFormula t stateType ->
   m SExp
@@ -257,7 +257,7 @@ sexpOfSallyStateFormula
 
 sexpOfSallyTransition ::
   MonadIO m =>
-  MonadReader [What4.SolverSymbol] m =>
+  MonadReader SallyNames m =>
   WriterConn t (SallyWriter ()) ->
   SallyTransition t ->
   m SExp
@@ -298,7 +298,7 @@ sexpOfSallySystem
 
 sexpOfSallyQuery ::
   MonadIO m =>
-  MonadReader [What4.SolverSymbol] m =>
+  MonadReader SallyNames m =>
   WriterConn sym (SallyWriter ()) ->
   SallyQuery sym ->
   m SExp
@@ -342,7 +342,9 @@ sexpOfSally
         newWriter
           noInput errorStream nullAcknowledgementAction
           "NoSolver" defaultWriteSMTLIB2Features bindings
-    let symbols = toListFC getConst (sallyStateVarsNames sallyState)
+    let symbols = SallyNames
+          (toListFC getConst (sallyStateInputsNames sallyState))
+          (toListFC getConst (sallyStateVarsNames sallyState))
     flip runReaderT symbols $ do
       state <- liftIO $ sexpOfSallyState conn sallyState
       formulas <- mapM (sexpOfSallyStateFormula conn) sallyFormulas

--- a/src/Language/Sally/TransitionSystem.hs
+++ b/src/Language/Sally/TransitionSystem.hs
@@ -47,17 +47,17 @@ mySallyNames =
 
 sallyState ::
   SallyNames ->
-  TS.TransitionSystem sym stateType ->
-  S.SallyState stateType Ctx.EmptyCtx
+  TS.TransitionSystem sym inputs stateType ->
+  S.SallyState stateType inputs
 sallyState
   (SallyNames {stateName})
-  (TS.TransitionSystem {TS.stateNames, TS.stateReprs}) =
+  (TS.TransitionSystem {TS.inputNames, TS.inputReprs, TS.stateNames, TS.stateReprs}) =
     S.SallyState
       { S.sallyStateName = stateName,
         S.sallyStateVars = stateReprs,
         S.sallyStateVarsNames = stateNames,
-        S.sallyStateInputs = Ctx.Empty,
-        S.sallyStateInputsNames = Ctx.Empty
+        S.sallyStateInputs = inputReprs,
+        S.sallyStateInputsNames = inputNames
       }
 
 sallyQuery :: S.Name -> What4.Pred (ExprBuilder t st fs) -> S.SallyQuery t
@@ -72,8 +72,8 @@ sallyQuery systemName sallyQueryPredicate =
 exportTransitionSystem ::
   ExprBuilder t st fs ->
   SallyNames ->
-  TS.TransitionSystem (ExprBuilder t st fs) stateType ->
-  IO (S.Sally t stateType Ctx.EmptyCtx Ctx.EmptyCtx)
+  TS.TransitionSystem (ExprBuilder t st fs) inputs stateType ->
+  IO (S.Sally t stateType inputs Ctx.EmptyCtx)
 exportTransitionSystem
   sym
   (sn@SallyNames {initialName, mainTransitionName, stateName, systemName})

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -43,7 +43,7 @@ showBinding (FnSymbolBinding x) = show x
 displayTransitionSystem ::
   sym ~ ExprBuilder t st fs =>
   sym ->
-  TransitionSystem sym stateFields ->
+  TransitionSystem sym inputFields stateFields ->
   IO ()
 displayTransitionSystem sym transitionSystem =
   do
@@ -138,15 +138,17 @@ counterTransitions sym state next =
 -- | TODO
 counterTransitionSystem ::
   ExprBuilder t st fs ->
-  IO (TransitionSystem (ExprBuilder t st fs) CounterStateType)
+  IO (TransitionSystem (ExprBuilder t st fs) Ctx.EmptyCtx CounterStateType)
 counterTransitionSystem sym =
   do
     return $
       TransitionSystem
-        { stateReprs = knownRepr,
+        { inputReprs = knownRepr,
+          inputNames = knownRepr,
+          stateReprs = knownRepr,
           stateNames = counterFieldNames,
           initialStatePredicate = counterInitial sym,
-          stateTransitions = counterTransitions sym,
+          stateTransitions = const $ counterTransitions sym,
           queries = const (pure [])
         }
 
@@ -222,14 +224,16 @@ realsTransitions sym state next =
 -- | TODO
 realsTransitionSystem ::
   ExprBuilder t st fs ->
-  IO (TransitionSystem (ExprBuilder t st fs) RealsStateType)
+  IO (TransitionSystem (ExprBuilder t st fs) Ctx.EmptyCtx RealsStateType)
 realsTransitionSystem sym =
   do
     return $
       TransitionSystem
-        { stateReprs = knownRepr,
+        { inputReprs = knownRepr,
+          inputNames = knownRepr,
+          stateReprs = knownRepr,
           stateNames = realsFieldNames,
           initialStatePredicate = realsInitial sym,
-          stateTransitions = realsTransitions sym,
+          stateTransitions = const $ realsTransitions sym,
           queries = const (pure [])
         }


### PR DESCRIPTION
(Depends on GaloisInc/what4#212.)

There was already some support for inputs (e.g. on `SallyState`), and this PR exposes them through the `what4-transition-system` interface.