### PR TITLE
Implement abduction-related methods in `what4`'s `SMTWriter` class

### DIFF
--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -27,7 +27,7 @@ common dependencies
   build-depends:
     , base                     >=4.8   && <4.16
     , parameterized-utils      >=2.0   && <2.2
-    , what4                    >=1.2
+    , what4                    >=1.3
     , what4-transition-system  >=0.0.3
 
 library

--- a/src/Language/Sally/Writer.hs
+++ b/src/Language/Sally/Writer.hs
@@ -230,6 +230,8 @@ instance SMTLib2Tweaks a => SMTWriter (SallyWriter a) where
 
   pushCommand _ = pure $ SMT2.push 1
   popCommand _ = pure $ SMT2.pop 1
+  push2Command _ = pure $ SMT2.push 2
+  pop2Command _ = pure $ SMT2.pop 2
   resetCommand _ = pure SMT2.resetAssertions
 
   checkCommands _ = [pure SMT2.checkSat]
@@ -238,6 +240,9 @@ instance SMTLib2Tweaks a => SMTWriter (SallyWriter a) where
 
   getUnsatAssumptionsCommand _ = pure SMT2.getUnsatAssumptions
   getUnsatCoreCommand _ = pure SMT2.getUnsatCore
+  getAbductCommand _ nm e = SMT2.getAbduct nm <$> e
+  getAbductNextCommand _ = pure SMT2.getAbductNext
+
   setOptCommand _ = (pure <$>) <$> SMT2.setOption
 
   declareCommand _proxy v argTypes retType =


### PR DESCRIPTION
This bumps the `what4` submodule to bring in the changes from GaloisInc/what4#213.  This requires implementing some new methods that were added to the `SMTWriter` class, which proves straightforward.