### PR TITLE
Adapt to changes in GaloisInc/what4#226

### DIFF
--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -27,7 +27,7 @@ common dependencies
   build-depends:
     , base                     >=4.8   && <4.17
     , parameterized-utils      >=2.0   && <2.2
-    , what4                    >=1.3
+    , what4                    >=1.4
     , what4-transition-system  >=0.0.3
 
 library

--- a/src/Language/Sally/Writer.hs
+++ b/src/Language/Sally/Writer.hs
@@ -257,6 +257,11 @@ instance SMTLib2Tweaks a => SMTWriter (SallyWriter a) where
     let resolveArg (var, Some tp) = (var, asSMT2Type @a tp)
      in SMT2.defineFun f (resolveArg <$> args) (asSMT2Type @a return_type) <$> e
 
+  synthFunCommand _proxy f args ret_tp =
+    pure $ SMT2.synthFun f (map (\(var, Some tp) -> (var, asSMT2Type @a tp)) args) (asSMT2Type @a ret_tp)
+  declareVarCommand _proxy v tp = pure $ SMT2.declareVar v (asSMT2Type @a tp)
+  constraintCommand _proxy e = SMT2.constraint <$> e
+
   stringTerm bs = pure $ smtlib2StringTerm @a bs
   stringLength x = smtlib2StringLength @a <$> x
   stringAppend xs = smtlib2StringAppend @a <$> sequence xs


### PR DESCRIPTION
GaloisInc/what4#226 adds some additional methods to `SMTWriter` that `language-sally` must implement.