### PR TITLE
Allow building with GHC 9.6

### DIFF
--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -25,7 +25,7 @@ source-repository head
 
 common dependencies
   build-depends:
-    , base                     >=4.8   && <4.18
+    , base                     >=4.8   && <4.19
     , parameterized-utils      >=2.0   && <2.2
     , what4                    >=1.4
     , what4-transition-system  >=0.0.3


### PR DESCRIPTION
This is a matter of bumping the upper version bounds on `base` and bumping the `what4` submodule to bring in the changes from https://github.com/GaloisInc/what4/pull/235.