### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/language-sally.cabal
+++ b/language-sally.cabal
@@ -25,7 +25,7 @@ source-repository head
 
 common dependencies
   build-depends:
-    , base                     >=4.8   && <4.19
+    , base                     >=4.8   && <4.20
     , parameterized-utils      >=2.0   && <2.2
     , what4                    >=1.4
     , what4-transition-system  >=0.0.3


### PR DESCRIPTION
This bumps the `what4` submodule and the upper version bounds on `base` to allow versions that are compatible with GHC 9.8.